### PR TITLE
UPDATE STRIGHT_FLUSH checking methods and test

### DIFF
--- a/src/main/java/kr/ac/cnu/games/poker/Extractor.java
+++ b/src/main/java/kr/ac/cnu/games/poker/Extractor.java
@@ -55,7 +55,7 @@ public class Extractor {
             }
 
             // 족보 순서대로 비교확인하여 일치하면 반환시
-            if(getStraightFlush(suitMap, integerMap)) return HandsType.STRIGHT_FLUSH;
+            if(getStraightFlush(suitMap, cardList)) return HandsType.STRIGHT_FLUSH;
             if(getFourCard(integerMap)) return HandsType.FOUR_CARD;
             if(getFullHouse(integerMap)) return HandsType.FULL_HOUSE;
             if(getFlush(suitMap)) return HandsType.FLUSH;
@@ -68,9 +68,31 @@ public class Extractor {
             return HandsType.NOTHING;
         }
 
-        // Straight Flush인지 확인하기 위한 함수, 조건에 맞기 위해서 Straight함수와 Flush함수 이용
-        private boolean getStraightFlush(Map<Suit, Integer> suitMap, Map<Integer, Integer> integerMap){
-            return getStraight(integerMap) && getFlush(suitMap);
+        //본래 Suit와 관계없이 STRIGHT여부를 계산하여 수정
+        private boolean getStraightFlush(Map<Suit, Integer> suitMap, List<Card> cardList){
+            Suit canFlush = null;//FLUSH가 될 수 있는 Suit를 임시저장할 변수
+            for(Suit key : suitMap.keySet()){
+                if(suitMap.get(key) == 5)
+                    canFlush = key;//FLUSH가 될 수 있는 Suit저장
+            }
+            if(canFlush == null)
+                return false;//FLUSH가 될 수 없다면 STRIGHT_FLUSH도 될 수 없음
+            List<Card> tempList = new ArrayList<>();//STRIGHT여부를 확인할 Card들을 임시저장할 변수
+            for(Card card : cardList){
+                if(card.getSuit() == canFlush)
+                    tempList.add(card);//canFlush에 저장된 Suit와 같은 Suit를 갖는 Card들 저장
+            }
+            Map<Integer, Integer> tempMap = new HashMap<Integer, Integer>();//tempList를 number, 개수로 맵핑할 변수
+            for(Card card : tempList){//임시 맵에 맵핑하는 반복문
+                if (tempMap.containsKey(card.getNumber())) {
+                    Integer count = tempMap.get(card.getNumber());
+                    count = count + 1;
+                    tempMap.put(card.getNumber(), count);
+                } else {
+                    tempMap.put(card.getNumber(), 1);
+                }
+            }
+            return getStraight(tempMap);//임시 맵으로 STRIGHT여부 판단 참일 경우 FLUSH이며 STRIGHT이므로 STRIGHT_FLUSH만족
         }
 
         // Four Card인지 확인하기 위한 함수

--- a/src/test/java/kr/ac/cnu/games/poker/ExtractorTest.java
+++ b/src/test/java/kr/ac/cnu/games/poker/ExtractorTest.java
@@ -16,11 +16,6 @@ import static org.junit.Assert.*;
 public class ExtractorTest {
     private Extractor extractor;
 
-    @Before
-    public void setUp() {
-        extractor = new Extractor();
-    }
-
     @Ignore
     @Test
     public void extractHighHands1() {
@@ -40,6 +35,27 @@ public class ExtractorTest {
         assertThat(hands.getHandsType(), is(HandsType.FLUSH));
         // 가장 높은 카드는 Ace (1 또는 14)인 1 이 되어야 한다.
         assertThat(hands.getCardList().stream().min(new HighCardComparator()).get().getNumber(), is(1));
+    }@Ignore
+    @Test
+    public void 스트레이트플러시테스트() {
+        List<Card> cardList = new ArrayList<>();
+        cardList.add(new Card(10, Suit.DIAMONDS));
+        cardList.add(new Card(11, Suit.DIAMONDS));
+        cardList.add(new Card(5, Suit.SPADES));
+        cardList.add(new Card(6, Suit.SPADES));
+        cardList.add(new Card(7, Suit.SPADES));
+        cardList.add(new Card(9, Suit.SPADES));
+        cardList.add(new Card(8, Suit.SPADES));
+
+
+        Hands hands = extractor.extractHighHands(cardList);
+        assertThat(hands.getHandsType(), is(HandsType.STRIGHT_FLUSH));
+        assertThat(hands.getCardList().stream().min(new HighCardComparator()).get().getNumber(), is(11));
+    }
+
+    @Before
+    public void setUp() {
+        extractor = new Extractor();
     }
 
     @Ignore


### PR DESCRIPTION
작성된 STRIGHT 확인 메소드는 Card들의 Suit와 상관없이 연속된 숫자를 가지는 카드가 5장이상이면 이를 STRIGHT로 판단함. 본래의 STRIGHT_FLUSH확인 메소드는 그런 STRIGHT와 FLUSH의 AND연산의 결과물을 반환하여 오류가 발생할 수 있음.
(ex) 1 DIAMONDS, 2 DIAMONDS, 3 HEARTS, 4 HEARTS, 5 HEARTS, 10 HEARTS, 11 HEARTS일 경우 1,2,3,4,5가 있어 STRIGHT이면서 5장의 HEARTS카드를 가지므로 STRIGHT_FLUSH로 판단하는 오류가 발생할 수 있음.